### PR TITLE
Evaluate only on missing data 

### DIFF
--- a/main.py
+++ b/main.py
@@ -163,8 +163,8 @@ def main(hparams):
     model = type(model).load_from_checkpoint(trainer.checkpoint_callback.best_model_path, prob_model=prob_model)
     test(model, prob_model, test_loader, hparams.device)
 
-    test_mie_ll(model, prob_model, train_loader.dataset, hparams.device, title='Train')
-    test_mie_ll(model, prob_model, test_loader.dataset, hparams.device)
+    test_mie_ll(model, prob_model, train_loader.dataset, hparams.device, title='Train', missing=False)
+    test_mie_ll(model, prob_model, test_loader.dataset, hparams.device, missing=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #1.

Adds an option to choose whether to use only the missing elements for evaluation. It still allows evaluating reconstruction with the training dataset.